### PR TITLE
[Add Module] Ambient Artillery Virtual

### DIFF
--- a/addons/modules/CfgPatches.hpp
+++ b/addons/modules/CfgPatches.hpp
@@ -11,6 +11,7 @@ class CfgPatches {
             "cba_main"
         };
         units[] = {
+            "MEH_moduleAmbientArtillery",
             "MEH_ModuleDeleteRespawnPosition",
             "MEH_ModuleEnableDisableGunLights",
             "MEH_ModuleMoveOnCombat",

--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -20,6 +20,7 @@ class CfgVehicles {
         };
     };
 
+    #include "\z\meh\addons\modules\modules\moduleAmbientArtilleryVirtual.hpp"
     #include "\z\meh\addons\modules\modules\moduleDeleteRespawnPosition.hpp"
     #include "\z\meh\addons\modules\modules\moduleEnableDisableGunLights.hpp"
     #include "\z\meh\addons\modules\modules\moduleMoveOnCombat.hpp"

--- a/addons/modules/XEH_PREP.sqf
+++ b/addons/modules/XEH_PREP.sqf
@@ -1,3 +1,4 @@
+PREP(moduleAmbientArtilleryVirtual);
 PREP(moduleDeleteRespawnPosition);
 PREP(moduleEnableDisableGunLights);
 PREP(moduleMoveOnCombat);
@@ -7,6 +8,7 @@ PREP(moduleVehicleMineJammer);
 PREP(moduleVehicleRearm);
 PREP(moduleVehicleRefuel);
 
+PREP(ambientArtilleryVirtual);
 PREP(deleteRespawnPosition);
 PREP(enableDisableGunLights);
 PREP(moveOnCombat);

--- a/addons/modules/functions/fnc_ambientArtilleryVirtual.sqf
+++ b/addons/modules/functions/fnc_ambientArtilleryVirtual.sqf
@@ -1,0 +1,79 @@
+#include "script_component.hpp"
+
+params [
+    ["_module", objNull, [objNull, []]],
+    ["_area", [100, 100, 0, false, -1], [[]], 5],
+    ["_shell", "Sh_82mm_AMOS", [""]],
+    ["_salvoSize", 6, [-1]],
+    ["_salvoInterval", 10, [-1]],
+    ["_salvoTimeVariation", 5, [-1]],
+    ["_shotInterval", 1, [-1]],
+    ["_shotTimeVariation", 1, [-1]]
+];
+
+// Verify variables
+if (_module isEqualType []) then {
+    _module = createVehicle ["Land_HelipadEmpty_F", _module];
+};
+_area = [getPosATL _module] + _area;
+
+if (
+    (!isClass (configFile >> "CfgAmmo" >> _shell)) ||
+    _salvoSize <= 0 ||
+    _salvoInterval < 0 ||
+    _salvoTimeVariation < 0 ||
+    _shotInterval < 0 ||
+    _shotTimeVariation < 0
+) exitWith {};
+
+// Execute
+private _arguments = [_module, _area, _shell, _salvoSize, _salvoInterval, _salvoTimeVariation, _shotInterval, _shotTimeVariation];
+
+_module setVariable [QGVAR(ambientArtillery_firing), false];
+
+private _handle = [{
+    params ["_args", "_handle"];
+    _args params ["_module", "_area", "_shell", "_salvoSize", "_salvoInterval", "_salvoTimeVariation", "_shotInterval", "_shotTimeVariation"];
+
+    // Exit code if module is dead or currently firing
+    if (!alive _module) exitWith {_handle call CBA_fnc_removePerFrameHandler};
+    private _isFiring = _module getVariable [QGVAR(ambientArtillery_firing), false];
+    if (_isFiring) exitWith {};
+
+    // Salvos firing
+    _module setVariable [QGVAR(ambientArtillery_firing), true];
+
+    for "_i" from 1 to _salvoSize do {
+        private _pos = [[_area]] call BIS_fnc_randomPos;
+        _pos set [2, 1000];
+
+        private _shotDelay = _shotInterval + (random [0, _shotTimeVariation / 2, _shotTimeVariation]);
+
+        [{
+            params ["_module", "_shell", "_salvoSize", "_salvoInterval", "_salvoTimeVariation", "_pos", "_index"];
+
+            private _round = createVehicle [_shell, _pos];
+            _round setVelocity [0, 0, -1000];
+
+            // Exit after last shot in salvo
+            private _lastRound = _index == _salvoSize;
+            if (_lastRound) then {
+                private _salvoDelay = _salvoInterval + (random [0, _salvoTimeVariation / 2, _salvoTimeVariation]);
+
+                TRACE_1("Salvo Delay", _salvoDelay);
+
+                // Set module to not firing to trigger the next salvo
+                [{
+                    params ["_module"];
+
+                    _module setVariable [QGVAR(ambientArtillery_firing), false];
+
+                    TRACE_1("Ending Salvo", _module getVariable [QGVAR(ambientArtillery_firing), false]);
+                }, [_module], _salvoDelay] call CBA_fnc_waitAndExecute;
+            };
+        }, [_module, _shell, _salvoSize, _salvoInterval, _salvoTimeVariation, _pos, _i], _shotDelay * _i] call CBA_fnc_waitAndExecute;
+    };
+}, 0.5, _arguments] call CBA_fnc_addPerFrameHandler;
+
+// Return
+_handle

--- a/addons/modules/functions/fnc_moduleAmbientArtilleryVirtual.sqf
+++ b/addons/modules/functions/fnc_moduleAmbientArtilleryVirtual.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+
+params [
+    ["_module", objNull, [objNull]],
+    "",
+    ["_isActivated", false, [true]]
+];
+
+if (!isServer) exitWith {};
+
+// Variables
+private _area = _module getVariable [QUOTE(ObjectArea), [100, 100, 0, false, -1]];
+private _shell = _module getVariable [QUOTE(Shell), "Sh_82mm_AMOS"];
+private _salvoSize = _module getVariable [QUOTE(SalvoSize), 6];
+private _salvoInterval = _module getVariable [QUOTE(SalvoInterval), 10];
+private _salvoTimeVariation = _module getVariable [QUOTE(SalvoTimeVariation), 5];
+private _shotInterval = _module getVariable [QUOTE(ShotInterval), 1];
+private _shotTimeVariation = _module getVariable [QUOTE(ShotTimeVariation), 1];
+
+// Verify variables
+if (
+    !isClass (configFile >> "CfgAmmo" >> _shell) ||
+    _salvoSize <= 0 ||
+    _salvoInterval < 0 ||
+    _salvoTimeVariation < 0 ||
+    _shotInterval < 0 ||
+    _shotTimeVariation < 0
+) exitWith {};
+
+// Execute
+if (_isActivated) then {
+    private _handle = [_module, _area, _shell, _salvoSize, _salvoInterval, _salvoTimeVariation, _shotInterval, _shotTimeVariation] call FUNC(ambientArtilleryVirtual);
+    _module setVariable [QGVAR(ambientArtilleryVirtual_Handle), _handle];
+} else {
+    private _handle = _module getVariable [QGVAR(ambientArtilleryVirtual_Handle), nil];
+    if (!isNil "_handle") then {
+        _handle call CBA_fnc_removePerFrameHandler;
+        _module setVariable [QGVAR(ambientArtilleryVirtual_Handle), nil];
+    };
+};

--- a/addons/modules/modules/moduleAmbientArtilleryVirtual.hpp
+++ b/addons/modules/modules/moduleAmbientArtilleryVirtual.hpp
@@ -1,0 +1,85 @@
+class MEH_moduleAmbientArtilleryVirtual: Module_F {
+    scope = 2;
+    displayName = CSTRING(ModuleAmbientArtilleryVirtual_DisplayName);
+    icon = "a3\ui_f\data\gui\cfg\communicationmenu\artillery_ca.paa";
+    category = "MEH";
+
+    function = QFUNC(ModuleAmbientArtilleryVirtual);
+    functionPriority = 1;
+    isGlobal = 0;
+    isTriggerActivated = 1;
+    isDisposable = 0;
+    is3DEN = 0;
+
+    canSetArea = 1;
+    canSetAreaShape = 1;
+    class AttributeValues {
+        size3[] = {100, 100, -1};
+        isRectangle = 0;
+    };
+
+    class Attributes: AttributesBase {
+        class Shell: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_Shell);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_Shell_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_Shell_Tooltip);
+            defaultValue = "'Sh_82mm_AMOS'";
+            typeName = "STRING";
+            validate = "STRING";
+        };
+
+        class SalvoSize: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_SalvoSize);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_SalvoSize_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_SalvoSize_Tooltip);
+            defaultValue = 6;
+            typeName = "NUMBER";
+            validate = "NUMBER";
+        };
+
+        class SalvoInterval: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_SalvoInterval);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_SalvoInterval_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_SalvoInterval_Tooltip);
+            defaultValue = 10;
+            typeName = "NUMBER";
+            validate = "NUMBER";
+        };
+
+        class SalvoTimeVariation: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_SalvoTimeVariation);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_SalvoTimeVariation_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_SalvoTimeVariation_Tooltip);
+            defaultValue = 5;
+            typeName = "NUMBER";
+            validate = "NUMBER";
+        };
+
+        class ShotInterval: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_ShotInterval);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_ShotInterval_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_ShotInterval_Tooltip);
+            defaultValue = 1;
+            typeName = "NUMBER";
+            validate = "NUMBER";
+        };
+
+        class ShotTimeVariation: Edit {
+            property = QGVAR(ModuleAmbientArtilleryVirtual_ShotTimeVariation);
+            displayName = CSTRING(ModuleAmbientArtilleryVirtual_ShotTimeVariation_DisplayName);
+            tooltip = CSTRING(ModuleAmbientArtilleryVirtual_ShotTimeVariation_Tooltip);
+            defaultValue = 1;
+            typeName = "NUMBER";
+            validate = "NUMBER";
+        };
+
+        class ModuleDescription: ModuleDescription {};
+    };
+
+    class ModuleDescription: ModuleDescription {
+        description = CSTRING(ModuleAmbientArtilleryVirtual_ModuleDescription_Description);
+        duplicate = 1;
+        position = 1;
+        direction = 1;
+    };
+};

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -181,5 +181,44 @@
         <Key ID="STR_MEH_Modules_ModuleEnableDisableGunLights_Attachment_Tooltip">
             <English>Flashlight to add.</English>
         </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_DisplayName">
+            <English>Ambient Artillery (Virtual)</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_Shell_DisplayName">
+            <English>Shell Type</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_Shell_Tooltip">
+            <English>The classname of a CfgAmmo shell class.</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoSize_DisplayName">
+            <English>Salvo Size</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoSize_Tooltip">
+            <English>The number of shots per salvo.</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoInterval_DisplayName">
+            <English>Salvo Interval</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoInterval_Tooltip">
+            <English>Interval between salvos.</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoTimeVariation_DisplayName">
+            <English>Salvo Time Variation</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_SalvoTimeVariation_Tooltip">
+            <English>Random amount (0 to value) to add to salvo interval.</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_ShotInterval_DisplayName">
+            <English>Shot Interval</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_ShotInterval_Tooltip">
+            <English>The time between salvos.</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_ShotTimeVariation_DisplayName">
+            <English>Shot Time Variation</English>
+        </Key>
+        <Key ID="STR_MEH_Modules_ModuleAmbientArtilleryVirtual_ShotTimeVariation_Tooltip">
+            <English>Random amount (0 to value) to add to shot interval.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Adds Ambient Artillery Virtual module. Allows for ambient artillery at a region without the use of any entities.