### PR TITLE
Beta Patch v0.6.1

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -6,7 +6,7 @@ mainprefix = "z"
 [version]
 major = 0
 minor = 6
-patch = 0
+patch = 1
 git_hash = 0
 
 [lint.sqf]

--- a/addons/modules/functions/fnc_moduleRegisterTeleporter.sqf
+++ b/addons/modules/functions/fnc_moduleRegisterTeleporter.sqf
@@ -35,6 +35,23 @@ _object = _object select 0;
 switch _mode do {
     case "init": {
         if (is3DEN) exitWith {};
+
+        // Register if no synced object
+        if (isNil "_object") then {
+            // Create object
+            private _flagClass = switch _side do {
+                case east: {"Flag_Red_F"};
+                case west: {"Flag_Blue_F"};
+                case independent: {"Flag_Green_F"};
+                default {"Flag_White_F"};
+            };
+            private _pos = getPosATL _module; _pos set [2, 0];
+            private _flag = createVehicle [_flagClass, _pos, [], 0, "NONE"];
+
+            _object = _flag;
+
+            INFO_2("(%1) No object synced, creating dummy flag for use: %2",QFUNC(moduleRegisterTeleporter),_object);
+        };
         
         INFO_2("(%1) Registering Teleporter: %2",QFUNC(moduleRegisterTeleporter),_object);
 

--- a/addons/modules/modules/moduleLightningStorm.hpp
+++ b/addons/modules/modules/moduleLightningStorm.hpp
@@ -45,6 +45,8 @@ class MEH_ModuleLightningStorm: MEH_ModuleBase {
             typeName = "NUMBER";
             validate = "NUMBER";
         };
+
+        class ModuleDescription: ModuleDescription {};
     };
 
     class ModuleDescription: ModuleDescription {

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -676,5 +676,8 @@
         <Key ID="STR_MEH_Modules_ModuleMPSync_VariableToPass_Tooltip">
             <English>The variable to set TRUE when sync is complete. Use this variable to start your mission scripts.\n\nExample:\n\nwaitUntil { myVariable }</English>
         </Key>
+        <Key ID="STR_MEH_Modules_ModuleRegisterTeleporter_ModuleDescription_Description">
+            <English>Registers the synchronized object to the teleporter pool. Activates the teleporter system if it has not been activated yet. Synchronized objects can be static, or vehicle.</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -89,10 +89,10 @@
             <English>Time (seconds) between vehicle rearms.\n0 to disable repeating.</English>
         </Key>
         <Key ID="STR_MEH_Modules_ModuleVehicleRefuel_ModuleDescription_Description">
-            <English>A module that will either refuel the synchronized vehicles once, or on a repeatable timer.\n0 to disable.</English>
+            <English>A module that will either refuel the synchronized vehicles once, or on a repeatable timer.&lt;br/&gt;0 to disable.</English>
         </Key>
         <Key ID="STR_MEH_Modules_ModuleVehicleRearm_ModuleDescription_Description">
-            <English>A module that will either rearm the synchronized vehicles once, or on a repeatable timer.\n0 to disable.</English>
+            <English>A module that will either rearm the synchronized vehicles once, or on a repeatable timer.&lt;br/&gt;0 to disable.</English>
         </Key>
         <Key ID="STR_MEH_Modules_ModuleVehicleMineJammer_DisplayName">
             <English>Vehicle Mine Jammer</English>

--- a/addons/teleporter/functions/fnc_createTeleporterAction.sqf
+++ b/addons/teleporter/functions/fnc_createTeleporterAction.sqf
@@ -16,7 +16,8 @@ private _actionID = _object addAction [
     nil, 1e6, true, true, "",
     toString {
         private _data = ["object", _target] call FUNC(getTeleporterData);
-        _data param [3, false];
+        side group _this == (_data param [2, sideUnknown]) &&
+        {_data param [3, false]}
     },
     5, false, "", ""
 ];

--- a/addons/teleporter/functions/fnc_teleportMenu_onLoad.sqf
+++ b/addons/teleporter/functions/fnc_teleportMenu_onLoad.sqf
@@ -19,8 +19,6 @@ private _data = GVAR(teleporterData);
 _data apply {
     _x params ["_name", "_object", "_side", "_bidirectional", "_travelTime", "_active"];
 
-    private _index = (_display displayCtrl IDC_LOCLIST) lbAdd _name;
-
     if (
         !alive _object ||
         !_active ||
@@ -28,6 +26,8 @@ _data apply {
     ) then {
         continue;
     };
+    
+    private _index = (_display displayCtrl IDC_LOCLIST) lbAdd _name;
 
     if (
         _object isKindOf "AllVehicles" &&


### PR DESCRIPTION
# Patch

Adds/modifies the following module descriptions:
- ModuleRegisterTeleporter
- ModuleLightningStorm

Fixes:

- Issue #52: Register teleporter module can now work independently of needing a synchronized object. The module will create a flag of appropriate color depending on the side attribute of the module. Flag will be placed at ground position where module was placed.

- Teleporter system now filters out side correctly preventing players from teleporting to another side's teleporters.

----------------------------------------------------------

Co-authored-by: R3voArma3