### PR TITLE
Fix inheritance for changeFlag module

### DIFF
--- a/addons/acecompat/CfgVehicles.hpp
+++ b/addons/acecompat/CfgVehicles.hpp
@@ -1,8 +1,10 @@
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
-        class AttributesBase
-        {
+        class AttributesBase;
+    };
+    class MEH_ModuleBase: Module_F {
+        class AttributesBase: AttributesBase {
             class Default;
             class Edit;
             class EditCodeMulti5;
@@ -14,10 +16,6 @@ class CfgVehicles {
             class ModuleDescription;
             class Units;
         };
-    };
-    class MEH_ModuleBase: Module_F {
-        class Attributes;
-        class AttributesBase;
         class ModuleDescription;
     };
 

--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -1,8 +1,19 @@
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
-        class AttributesBase
-        {
+        class AttributesBase;
+        class ModuleDescription;
+    };
+    class MEH_ModuleBase: Module_F {
+        author = "Hypoxic";
+        scope = 0;
+        scopeCurator = 0;
+        is3DEN = 0;
+        isGlobal = 0;
+        isTriggerActivated = 1;
+        curatorCanAttach = 0;
+
+        class AttributesBase: AttributesBase {
             class Default;
             class Edit;
             class EditCodeMulti5;
@@ -14,17 +25,6 @@ class CfgVehicles {
             class ModuleDescription;
             class Units;
         };
-
-        class ModuleDescription;
-    };
-    class MEH_ModuleBase: Module_F {
-        author = "Hypoxic";
-        scope = 0;
-        scopeCurator = 0;
-        is3DEN = 0;
-        isGlobal = 0;
-        isTriggerActivated = 1;
-        curatorCanAttach = 0;
 
         class ModuleDescription: ModuleDescription {
             duplicate = 0;


### PR DESCRIPTION
- Fix inheritance for the change flag module
- `AttributesBase` seems to have weird inheritance, as the class was empty unless adding `class AttributesBase: AttributesBase {}` to `MEH_ModuleBase`