### PR TITLE
Patch v1.2.0

### DIFF
--- a/addons/common/Display3DEN.hpp
+++ b/addons/common/Display3DEN.hpp
@@ -14,7 +14,8 @@ class Display3DEN
                         "MEH_About_Contributing",
                         "MEH_About_Documentation",
                         "MEH_About_Credits",
-                        "MEH_About_BugReport"
+                        "MEH_About_BugReport",
+                        "MEH_About_Discord"
                     };
                 };
                 class MEH_About_Changelog {
@@ -42,6 +43,10 @@ class Display3DEN
                 class MEH_About_BugReport: MEH_About_Changelog {
                     text = CSTRING(About_BugReport);
                     weblink = "https://github.com/hypoxia125/Modules-Enhanced/issues";
+                };
+                class MEH_About_Discord: MEH_About_Changelog {
+                    text = "Discord";
+                    weblink = "https://discord.gg/dn4eGEf4m8";
                 };
             };
         };

--- a/addons/common/functions/fnc_3DEN_3DModuleMarkers.sqf
+++ b/addons/common/functions/fnc_3DEN_3DModuleMarkers.sqf
@@ -13,10 +13,16 @@ addMissionEventHandler ["Draw3D", {
     {
         private _module = _x;
         private _pos = ASLtoAGL getPosASL _module;
+
         private _distance = _pos distance get3DENCamera;
         if (_distance >= [QGVAR(ModuleMarkerDistanceLimit), "priority"] call CBA_settings_fnc_get) then { continue };
-        private _textSize = (1 * (50 / _distance) max 0.2) min 0.03;
 
+        private _text = getText (configFile >> "CfgVehicles" >> typeOf _module >> "displayName");
+        if (_text == "") then {
+            _text = typeOf _module;
+        };
+
+        private _textSize = (1 * (50 / _distance) max 0.2) min 0.03;
         private _color = [QGVAR(ModuleMarkerColor), "priority"] call CBA_settings_fnc_get;
 
         drawIcon3D [
@@ -26,7 +32,7 @@ addMissionEventHandler ["Draw3D", {
             1 * (50 / _distance) max 0.5,
             1 * (50 / _distance) max 0.5,
             0,
-            typeOf _module,
+            _text,
             0,
             _textSize
         ]

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,5 +1,5 @@
 #define MAJOR 1
-#define MINOR 1
+#define MINOR 2
 #define PATCH 0
 
-#define CURRENT_VERSION "1.1.0"
+#define CURRENT_VERSION "1.2.0"

--- a/addons/modules/modules/moduleEffectFire.hpp
+++ b/addons/modules/modules/moduleEffectFire.hpp
@@ -1,6 +1,6 @@
 class MEH_ModuleEffectFire: MEH_ModuleBase {
     scope = 2;
-    displayName = CSTRING(ModuleEffectFire_DisplayName);
+    displayName = "Fire";
     icon = "a3\ui_f\data\igui\cfg\actions\obsolete\ui_action_fire_in_flame_ca.paa";
     category = "MEH_Effects";
 

--- a/addons/modules/modules/moduleEffectLightpoint.hpp
+++ b/addons/modules/modules/moduleEffectLightpoint.hpp
@@ -1,6 +1,6 @@
 class MEH_ModuleEffectLightpoint: MEH_ModuleBase {
     scope = 2;
-    displayName = CSTRING(ModuleEffectLightpoint_DisplayName);
+    displayName = "Lightpoint";
     icon = "a3\modules_f_curator\data\portraitflare_ca.paa";
     category = "MEH_Effects";
 

--- a/addons/modules/modules/moduleEffectSmoke.hpp
+++ b/addons/modules/modules/moduleEffectSmoke.hpp
@@ -1,6 +1,6 @@
 class MEH_ModuleEffectSmoke: MEH_ModuleBase {
     scope = 2;
-    displayName = CSTRING(ModuleEffectSmoke_DisplayName);
+    displayName = "Smoke";
     icon = "a3\modules_f_curator\data\iconsmoke_ca.paa";
     category = "MEH_Effects";
 

--- a/addons/modules/modules/moduleParadropVehicle.hpp
+++ b/addons/modules/modules/moduleParadropVehicle.hpp
@@ -74,7 +74,7 @@ class MEH_ModuleParadropVehicle: MEH_ModuleBase {
         };
 
         class Expression: Edit {
-            control = QUOTE(EditMulti3);
+            control = QUOTE(EditCodeMulti5);
             property = QGVAR(ModuleParadropVehicle_Expression);
             displayName = CSTRING(ModuleParadropVehicle_Expression_DisplayName);
             tooltip = CSTRING(ModuleParadropVehicle_Expression_Tooltip);


### PR DESCRIPTION
Patch v1.2.0

- Adds discord link to top bar
- Removes the "Effect" prefix from some module names
- Changes the 3D names of modules to the displayName with module type as a backup
- Changes expression box of ParadropVehicle to be larger and not scrolling