### PR TITLE
Patch v1.6.2

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,5 +1,5 @@
 #define MAJOR 1
 #define MINOR 6
-#define PATCH 1
+#define PATCH 2
 
-#define CURRENT_VERSION "1.6.1"
+#define CURRENT_VERSION "1.6.2"

--- a/addons/modules/functions/fnc_moduleParadropTroopTransport.sqf
+++ b/addons/modules/functions/fnc_moduleParadropTroopTransport.sqf
@@ -129,9 +129,14 @@ private _execute = {
                     _args params ["_chuteOpenHeight", "_chuteType", "_trailingSmoke", "_paradrop"];
 
                     private _leader = leader group _caller;
+                    private _paradropVehicle = _target;
 
                     if (_leader == _caller) then {
                         units group _caller apply {
+                            if !(_x in _paradropVehicle) then {
+                                LOG_1("ParadropTroopTransport:: Unit [%1] not in paradrop vehicle, skipping...",_x);
+                                continue;
+                            };
                             [_x, _chuteOpenHeight, _chuteType, _trailingSmoke] call _paradrop;
                             sleep 1;
                         };

--- a/workshop/Description.md
+++ b/workshop/Description.md
@@ -1,6 +1,6 @@
 [img]https://i.imgur.com/NrstAKw.gif[/img]
 
-[h1]Current Version - v1.5.3[/h1]
+[h1]Current Version - v1.6.2[/h1]
 
 Join the [url=https://discord.gg/dn4eGEf4m8]Modules Enhanced Discord[/url]
 
@@ -35,10 +35,13 @@ Visit the [url=https://github.com/hypoxia125/Modules-Enhanced/issues]GitHub Issu
 - Change Flag
 - Clear Map Location Names
 - Communication Jammer
+- Create Map Location
 - Create Minefield
 - Create Remote Target
 - Create Paradrop Troop Transport
 - Delete BI Respawn Position
+- Earthquake Damage Area
+- Earthquake Epicenter
 - Fire
 - Flare Launcher
 - Lightpoint


### PR DESCRIPTION
[ModuleParadropTroopTransport]
- Skips paradropping units that are not in the paradrop vehicle.